### PR TITLE
Adding the DPI awareness setting to fix incomplete screenshots

### DIFF
--- a/bofdefs.h
+++ b/bofdefs.h
@@ -70,6 +70,9 @@ DECLSPEC_IMPORT DWORD WINAPI User32$GetWindowThreadProcessId(HWND hWnd, LPDWORD 
     DECLSPEC_IMPORT int WINAPI User32$GetSystemMetrics(int nIndex);
 #define GetSystemMetrics User32$GetSystemMetrics
 
+    DECLSPEC_IMPORT BOOL WINAPI User32$SetProcessDPIAware();
+#define SetProcessDPIAware User32$SetProcessDPIAware
+
     DECLSPEC_IMPORT HDC WINAPI User32$GetDC(HWND hWnd);
 #define GetDC User32$GetDC
 

--- a/entry.cpp
+++ b/entry.cpp
@@ -704,7 +704,9 @@ void go(char* buff, int len)
 
     if (debug)
         BeaconPrintf(CALLBACK_OUTPUT, "[DEBUG] go() called with filename: %s, savemethod: %d, pid: %d, debug: %d", filename, savemethod, pid, debug);
-
+    
+    BOOL dpi = SetProcessDPIAware(); // Set DPI awareness to fix incomplete screenshots
+    
     HBITMAP hBitmap = NULL;
     if (pid != 0) {
         if (debug)


### PR DESCRIPTION
There is a classic problem: if the user's display scaling is not set to 100%:
![Snipaste_2025-04-22_18-01-26](https://github.com/user-attachments/assets/779b740a-072d-4648-b995-c02b4b82b4ec)

The screen size obtained by GDI is not the actual physical pixel size, which results in incomplete screenshots:
![test](https://github.com/user-attachments/assets/01bee8ea-88b2-42e2-8f2e-5fdaf584f388)

To fix this, we need to call `SetProcessDPIAware` before obtaining the screen size.

After that, everything works as expected:
![test1](https://github.com/user-attachments/assets/0168dc36-d20e-4645-9910-1bb04f9ec104)

